### PR TITLE
Proxy support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,20 +1,30 @@
 'use strict';
 var got = require('got');
 var registryUrl = require('registry-url')();
-var Promise = require('pinkie-promise');
+var path = require('path');
+var NPMRC = process.env.NPMRC || path.join(process.env.HOME || process.env.USERPROFILE, '.npmrc');
+var properties = require('properties');
+var ProxyAgent = require('proxy-agent');
+
+function config() {
+	return new Promise(function (resolve) {
+		properties.parse(NPMRC, {
+			path: true
+		}, function (error, obj) {
+			if (error) {
+				return resolve(null);
+			}
+			return resolve(obj[Object.keys(obj).find((value) => value === 'https-proxy')]);
+		});
+	});
+}
 
 module.exports = function (name) {
 	if (!(typeof name === 'string' && name.length !== 0)) {
 		return Promise.reject(new Error('Package name required'));
 	}
-
-	return got.head(registryUrl + name.toLowerCase()).then(function () {
-		return false;
-	}).catch(function (err) {
-		if (err.statusCode === 404) {
-			return true;
-		}
-
-		throw err;
-	});
+	return config()
+	.then((url) => got.head(registryUrl + name.toLowerCase(), url ? {agent: new ProxyAgent(url)} : {}))
+	.then(() => false)
+	.catch((err) => err.statusCode === 404 ? true : err);
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "sindresorhus.com"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.12.0"
   },
   "scripts": {
     "test": "xo && ava"
@@ -30,7 +30,8 @@
   ],
   "dependencies": {
     "got": "^5.0.0",
-    "pinkie-promise": "^2.0.0",
+    "properties": "^1.2.1",
+    "proxy-agent": "^2.0.0",
     "registry-url": "^3.0.0"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,8 @@ npmName('chalk').then(available => {
 });
 ```
 
+## Proxy support
+The module will look for a .npmrc file on the user's home folder or for the NPMRC environment variable for the https-proxy entry.
 
 ## Related
 


### PR DESCRIPTION
Hi,
I work on a government company that uses proxies, so this npm-name module was preventing me to use the generator-node from the yeoman team because of the lack of proxy support.
As this is a utility for npm name discovery I believe that it makes sense to depend on the configurations from the npmrc file.
Firstly it looks for the npmrc file, then for a https-proxy entry and then passes the url of the proxy to got.
I had to use proxy-agent because tunnel was giving me a "Parse Error" error.
Hope it helps :-)

Alex