### PR TITLE
Fix scoped package name support

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ function request(name) {
 		return Promise.reject(err);
 	}
 
-	if (isScoped(name)) {
+	const isScopedRepo = isScoped(name);
+	if (isScoped) {
 		name = name.replace(/\//g, '%2f');
 	}
 
@@ -26,6 +27,10 @@ function request(name) {
 		.then(() => false)
 		.catch(err => {
 			if (err.statusCode === 404) {
+				return true;
+			}
+
+			if (err.statusCode === 401 && isScopedRepo) {
 				return true;
 			}
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function request(name) {
 	}
 
 	const isScopedRepo = isScoped(name);
-	if (isScoped) {
+	if (isScopedRepo) {
 		name = name.replace(/\//g, '%2f');
 	}
 

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function request(name) {
 				return true;
 			}
 
-			if (err.statusCode === 401 && isScopedRepo) {
+			if (isScopedRepo && err.statusCode === 401) {
 				return true;
 			}
 


### PR DESCRIPTION
@sindresorhus 
Fixes an error where it appears the npm registry api has changed to return a 401 if you try to access a scoped url that doesn't exist.
Should fix issue with other pr in np: https://github.com/sindresorhus/np/pull/258