### PR TITLE
Fix typosquatting false-positives

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function request(name) {
 		name = name.replace(/\//g, '%2f');
 	}
 
-	return got.head(registryUrl + name.toLowerCase(), {timeout: 10000})
+	return got.head(registryUrl + name.toLowerCase().replace(/[-_.]/g, ''), {timeout: 10000})
 		.then(() => false)
 		.catch(err => {
 			if (err.statusCode === 404) {

--- a/test.js
+++ b/test.js
@@ -10,6 +10,11 @@ test('returns false when package name is taken', async t => {
 	t.false(await m('chalk'));
 });
 
+// https://blog.npmjs.org/post/168978377570/new-package-moniker-rules
+test('returns false when package name is moniker-similar', async t => {
+	t.false(await m('c_h-a.l-k'));
+});
+
 test('returns a map of multiple package names', async t => {
 	const name1 = 'chalk';
 	const name2 = uniqueString();


### PR DESCRIPTION
hi there! `npm` updated their rules around package name closeness recently.

Just spent a month emailing people an `npm` about possibly relaxing the rule for one of my new packages; to no avail. Even with the author of the similar-named package's permission.

Anyway, this might save some people similar frustration in the future. Fixes #15


Seems like the test failure is the same 401 as master. Ru-lai's pr will probably need merged first.