### PR TITLE
Revert moniker replacements

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ const request = async name => {
 	}
 };
 
-module.exports = async name => {
+module.exports = name => {
 	if (!(typeof name === 'string' && name.length > 0)) {
 		throw new Error('Package name required');
 	}

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const request = async name => {
 	}
 
 	try {
-		await got.head(registryUrl + name.toLowerCase().replace(/[-_.]/g, ''), {timeout: 10000});
+		await got.head(registryUrl + name.toLowerCase(), {timeout: 10000});
 		return false;
 	} catch (error) {
 		if (error.statusCode === 404) {

--- a/test.js
+++ b/test.js
@@ -10,11 +10,6 @@ test('returns false when package name is taken', async t => {
 	t.false(await m('chalk'));
 });
 
-// https://blog.npmjs.org/post/168978377570/new-package-moniker-rules
-test('returns false when package name is moniker-similar', async t => {
-	t.false(await m('c_h-a.l-k'));
-});
-
 test('returns a map of multiple package names', async t => {
 	const name1 = 'chalk';
 	const name2 = uniqueString();

--- a/test.js
+++ b/test.js
@@ -23,7 +23,7 @@ test('returns true when scoped package name is not taken', async t => {
 });
 
 test('returns false when scoped package name is taken', async t => {
-	t.false(await m(`@sindresorhus/is`));
+	t.false(await m('@sindresorhus/is'));
 });
 
 test('throws when package name is invalid', async t => {


### PR DESCRIPTION
We cannot do replacements in the requested name as the npm API does support the shortened names so the only way to check if a name would be rejected for typosquatting is to try every combination of characters in every position which seems impractical and would perform really bad.

So until npm exposes an API to check names, we're just checking the name as-is.