### PR TITLE
Update `is-url-superb` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	"dependencies": {
 		"got": "^10.6.0",
 		"is-scoped": "^2.1.0",
-		"is-url-superb": "^3.0.0",
+		"is-url-superb": "^4.0.0",
 		"lodash.zip": "^4.2.0",
 		"org-regex": "^1.0.0",
 		"p-map": "^3.0.0",


### PR DESCRIPTION
Untested, but this sheds a transitive dependency on url-regex which has an unpatched vulnerability