### PR TITLE
Handle typosquat restrictions

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,11 @@ const request = async (name, options) => {
 		throw error;
 	}
 
+	let urlName = name;
 	const isScopedPackage = isScoped(name);
+	if (isScopedPackage) {
+		urlName = name.replace(/\//g, '%2f');
+	}
 
 	const authInfo = registryAuthToken(registryUrl, {recursive: true});
 	const headers = {};
@@ -41,11 +45,6 @@ const request = async (name, options) => {
 	}
 
 	try {
-		let urlName = name;
-		if (isScopedPackage) {
-			urlName = name.replace(/\//g, '%2f');
-		}
-
 		if (isOrganization) {
 			await got.head(npmOrganizationUrl + urlName.toLowerCase(), {timeout: 10000});
 		} else {

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const zip = require('lodash.zip');
 const validate = require('validate-npm-package-name');
 const organizationRegex = require('org-regex')({exact: true});
 const pMap = require('p-map');
+const {isTaken} = require('is-name-taken');
 
 class InvalidNameError extends Error {}
 
@@ -32,9 +33,6 @@ const request = async (name, options) => {
 	}
 
 	const isScopedPackage = isScoped(name);
-	if (isScopedPackage) {
-		name = name.replace(/\//g, '%2f');
-	}
 
 	const authInfo = registryAuthToken(registryUrl, {recursive: true});
 	const headers = {};
@@ -43,10 +41,15 @@ const request = async (name, options) => {
 	}
 
 	try {
+		let urlName = name;
+		if (isScopedPackage) {
+			urlName = name.replace(/\//g, '%2f');
+		}
+
 		if (isOrganization) {
-			await got.head(npmOrganizationUrl + name.toLowerCase(), {timeout: 10000});
+			await got.head(npmOrganizationUrl + urlName.toLowerCase(), {timeout: 10000});
 		} else {
-			await got.head(registryUrl + name.toLowerCase(), {timeout: 10000, headers});
+			await got.head(registryUrl + urlName.toLowerCase(), {timeout: 10000, headers});
 		}
 
 		return false;
@@ -54,6 +57,11 @@ const request = async (name, options) => {
 		const {statusCode} = error.response;
 
 		if (statusCode === 404) {
+			if (!isOrganization) {
+				const conflict = await isTaken(name.toLowerCase());
+				return !conflict;
+			}
+
 			return true;
 		}
 

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ const request = async (name, options) => {
 
 		if (statusCode === 404) {
 			if (!isOrganization) {
-				const conflict = await isTaken(name.toLowerCase());
+				const conflict = await isTaken(name.toLowerCase(), {maxAge: 60000});
 				return !conflict;
 			}
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 	],
 	"dependencies": {
 		"got": "^10.6.0",
-		"is-name-taken": "^1.1.1",
+		"is-name-taken": "^2.0.0",
 		"is-scoped": "^2.1.0",
 		"is-url-superb": "^4.0.0",
 		"lodash.zip": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 	],
 	"dependencies": {
 		"got": "^10.6.0",
+		"is-name-taken": "^1.0.2",
 		"is-scoped": "^2.1.0",
 		"is-url-superb": "^4.0.0",
 		"lodash.zip": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 	],
 	"dependencies": {
 		"got": "^10.6.0",
-		"is-name-taken": "^1.1.0",
+		"is-name-taken": "^1.1.1",
 		"is-scoped": "^2.1.0",
 		"is-url-superb": "^4.0.0",
 		"lodash.zip": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 	],
 	"dependencies": {
 		"got": "^10.6.0",
-		"is-name-taken": "^1.0.2",
+		"is-name-taken": "^1.1.0",
 		"is-scoped": "^2.1.0",
 		"is-url-superb": "^4.0.0",
 		"lodash.zip": "^4.2.0",

--- a/test.js
+++ b/test.js
@@ -27,6 +27,11 @@ test('returns false when package name is taken', async t => {
 	t.false(await npmName('np', options));
 });
 
+test('returns false when package name is taken, regardless of punctuation', async t => {
+	t.false(await npmName('ch-alk'));
+	t.false(await npmName('recursivereaddir'));
+});
+
 test('returns false when organization name is taken', async t => {
 	t.false(await npmName('@ava'));
 	t.false(await npmName('@ava/'));


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/npm-name/issues/15

This solution should account for punctuation using [is-name-taken](https://github.com/bconnorwhite/is-name-taken), which caches the bulk of npm package names so that only the last few need to be fetched.

One thing to note is that npmName.many is kinda slow as it causes multiple requests to sync the list of packages. Instead, the list of names should really all be sent off to is-name-taken together. If anyone wants, I can add this as well.